### PR TITLE
raise error if vector divided by zero

### DIFF
--- a/contract/contracts/packages/graphics/Vector.sol
+++ b/contract/contracts/packages/graphics/Vector.sol
@@ -34,6 +34,7 @@ library Vector {
   }
 
   function div(Struct memory _vector, int _value) internal pure returns(Struct memory newVector) {
+    require(_value != 0, "Not allow division by zero")
     newVector.x = _vector.x / _value;
     newVector.y = _vector.y / _value;
   }


### PR DESCRIPTION
Since user could divide vector by 0, I fixed it to raise error when user divide vector by zero.