### PR TITLE
stop animation on purchase cancel

### DIFF
--- a/src/components/TokenActions.vue
+++ b/src/components/TokenActions.vue
@@ -151,6 +151,7 @@ export default defineComponent({
       } catch (e) {
         console.error(e);
         alert("Sorry, purchase failed with:" + e);
+        isExecuting.value = 0; // non-execute
       }
     };
 


### PR DESCRIPTION
Buy ボタンを押した後に、Metamask で Reject した際にアニメーションが終わらないバグを修正しました。