### PR TITLE
duplicate from sushi-Nouns(correct ver)

### DIFF
--- a/contract/contracts/LocalNounsToken.sol
+++ b/contract/contracts/LocalNounsToken.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+
+/*
+ * Created by Isamu Arimoto (@isamua)
+ */
+
+pragma solidity ^0.8.6;
+
+import '@openzeppelin/contracts/utils/Strings.sol';
+import './libs/ProviderTokenA1.sol';
+import { INounsSeeder } from './sushi/interfaces/INounsSeeder.sol';
+import './sushi/interfaces/IAssetProviderExMint.sol';
+
+contract SushiNounsToken is ProviderTokenA1 {
+  using Strings for uint256;
+
+  // fes committee
+  address public committee;
+  address public designer;
+  address public developper;
+
+  IAssetProviderExMint public assetProvider2;
+
+  constructor(
+    IAssetProviderExMint _assetProvider,
+    address _committee,
+    address _designer,
+    address _developper
+  ) ProviderTokenA1(_assetProvider, 'Sushi Nouns', 'Sushi Nouns') {
+    description = 'Sushi Nouns Token.';
+    assetProvider2 = _assetProvider;
+    mintPrice = 1e15; // 0.1 
+    mintLimit = 5000;
+    committee = _committee;
+    designer = _designer;
+    developper = _developper;
+  }
+
+  function tokenName(uint256 _tokenId) internal pure override returns (string memory) {
+    return string(abi.encodePacked('Sushi Nouns ', _tokenId.toString()));
+  }
+  function tokenURI(uint256 _tokenId) public view override returns (string memory) {
+      require(_tokenId < _nextTokenId(), 'SushiNounsToken.tokenURI: nonexistent token');
+
+      (string memory svgPart, string memory tag) = assetProvider2.generateSVGPart(_tokenId);
+      bytes memory image = bytes(svgPart);
+          
+          return
+      string(
+        abi.encodePacked(
+          'data:application/json;base64,',
+          Base64.encode(
+            bytes(
+              abi.encodePacked(
+                '{"name":"',
+                tokenName(_tokenId),
+                '","description":"',
+                description,
+                '","attributes":[',
+                generateTraits(_tokenId),
+                '],"image":"data:image/svg+xml;base64,',
+                Base64.encode(image),
+                '"}'
+              )
+            )
+          )
+        )
+      );
+  }
+  function mint() public payable virtual override returns (uint256 tokenId) {
+      require(msg.value >= mintPrice, 'Must send the mint price');
+      assetProvider2.mint(_nextTokenId());
+      super.mint();
+      address payable payableTo = payable(committee);
+      payableTo.transfer(address(this).balance);
+      
+      if ((_nextTokenId() % 10) == 8) {
+          assetProvider2.mint(_nextTokenId());
+          _safeMint(designer, 1);
+          assetProvider2.mint(_nextTokenId());
+          _safeMint(developper, 1);
+      }
+      return _nextTokenId() - 1;
+  }
+}

--- a/contract/contracts/LocalNounsToken.sol
+++ b/contract/contracts/LocalNounsToken.sol
@@ -11,7 +11,7 @@ import './libs/ProviderTokenA1.sol';
 import { INounsSeeder } from './sushi/interfaces/INounsSeeder.sol';
 import './sushi/interfaces/IAssetProviderExMint.sol';
 
-contract SushiNounsToken is ProviderTokenA1 {
+contract LocalNounsToken is ProviderTokenA1 {
   using Strings for uint256;
 
   // fes committee

--- a/contract/contracts/localNouns/LocalNounsDescriptor.sol
+++ b/contract/contracts/localNouns/LocalNounsDescriptor.sol
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: GPL-3.0
+
+/// @title The Nouns NFT descriptor
+
+/*********************************
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░██░░░████░░██░░░████░░░ *
+ * ░░██████░░░████████░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ *********************************/
+
+pragma solidity ^0.8.6;
+
+import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
+import { Strings } from '@openzeppelin/contracts/utils/Strings.sol';
+import { INounsDescriptor } from './interfaces/INounsDescriptor.sol';
+import { INounsSeeder } from './interfaces/INounsSeeder.sol';
+import { MultiPartRLEToSVG } from '../external/nouns/libs/MultiPartRLEToSVG.sol';
+import { NFTDescriptor } from '../external/nouns/libs/NFTDescriptor.sol';
+
+contract SushiNounsDescriptor is INounsDescriptor, Ownable {
+    using Strings for uint256;
+
+    // original
+    INounsDescriptor public immutable descriptor;
+
+    // prettier-ignore
+    // https://creativecommons.org/publicdomain/zero/1.0/legalcode.txt
+    bytes32 constant COPYRIGHT_CC0_1_0_UNIVERSAL_LICENSE = 0xa2010f343487d3f7618affe54f789f5487602331c0a8d03f49e9a7c547cf0499;
+
+    // Whether or not new Noun parts can be added
+    bool public override arePartsLocked;
+
+    // Whether or not `tokenURI` should be returned as a data URI (Default: true)
+    bool public override isDataURIEnabled = true;
+
+    // Base URI
+    string public override baseURI;
+
+    // Noun Color Palettes (Index => Hex Colors)
+    mapping(uint8 => string[]) public override palettes;
+
+    // Noun Backgrounds (Hex Colors)
+    string[] public override backgrounds;
+
+    // Noun Bodies (Custom RLE)
+    bytes[] public override bodies;
+
+    // Noun Accessories (Custom RLE)
+    bytes[] public override accessories;
+
+    // Noun Heads (Custom RLE)
+    bytes[] public override heads;
+
+    // Noun Glasses (Custom RLE)
+    bytes[] public override glasses;
+
+    constructor(INounsDescriptor _descriptor) {
+        descriptor = _descriptor;
+    }
+    /**
+     * @notice Require that the parts have not been locked.
+     */
+    modifier whenPartsNotLocked() {
+        require(!arePartsLocked, 'Parts are locked');
+        _;
+    }
+
+    /**
+     * @notice Get the number of available Noun `backgrounds`.
+     */
+    function backgroundCount() external view override returns (uint256) {
+        return backgrounds.length;
+    }
+
+    /**
+     * @notice Get the number of available Noun `bodies`.
+     */
+    function bodyCount() external view override returns (uint256) {
+        return descriptor.bodyCount();
+        // return bodies.length;
+    }
+
+    /**
+     * @notice Get the number of available Noun `accessories`.
+     */
+    function accessoryCount() external view override returns (uint256) {
+        return accessories.length;
+    }
+
+    /**
+     * @notice Get the number of available Noun `heads`.
+     */
+    function headCount() external view override returns (uint256) {
+        return heads.length;
+    }
+
+    /**
+     * @notice Get the number of available Noun `glasses`.
+     */
+    function glassesCount() external view override returns (uint256) {
+        return descriptor.glassesCount();
+        // return glasses.length;
+    }
+
+    /**
+     * @notice Add colors to a color palette.
+     * @dev This function can only be called by the owner.
+     */
+    function addManyColorsToPalette(uint8 paletteIndex, string[] calldata newColors) external override onlyOwner {
+        require(palettes[paletteIndex].length + newColors.length <= 256, 'Palettes can only hold 256 colors');
+        for (uint256 i = 0; i < newColors.length; i++) {
+            _addColorToPalette(paletteIndex, newColors[i]);
+        }
+    }
+
+    /**
+     * @notice Batch add Noun backgrounds.
+     * @dev This function can only be called by the owner when not locked.
+     */
+    function addManyBackgrounds(string[] calldata _backgrounds) external override onlyOwner whenPartsNotLocked {
+        for (uint256 i = 0; i < _backgrounds.length; i++) {
+            _addBackground(_backgrounds[i]);
+        }
+    }
+
+    /**
+     * @notice Batch add Noun bodies.
+     * @dev This function can only be called by the owner when not locked.
+     */
+    function addManyBodies(bytes[] calldata _bodies) external override onlyOwner whenPartsNotLocked {
+        for (uint256 i = 0; i < _bodies.length; i++) {
+            _addBody(_bodies[i]);
+        }
+    }
+    
+    /**
+     * @notice Batch add Noun accessories.
+     * @dev This function can only be called by the owner when not locked.
+     */
+    function addManyAccessories(bytes[] calldata _accessories) external override onlyOwner whenPartsNotLocked {
+        for (uint256 i = 0; i < _accessories.length; i++) {
+            _addAccessory(_accessories[i]);
+        }
+    }
+
+    /**
+     * @notice Batch add Noun heads.
+     * @dev This function can only be called by the owner when not locked.
+     */
+    function addManyHeads(bytes[] calldata _heads) external override onlyOwner whenPartsNotLocked {
+        for (uint256 i = 0; i < _heads.length; i++) {
+            _addHead(_heads[i]);
+        }
+    }
+
+    /**
+     * @notice Batch add Noun glasses.
+     * @dev This function can only be called by the owner when not locked.
+     */
+    function addManyGlasses(bytes[] calldata _glasses) external override onlyOwner whenPartsNotLocked {
+        for (uint256 i = 0; i < _glasses.length; i++) {
+            _addGlasses(_glasses[i]);
+        }
+    }
+    
+    /**
+     * @notice Add a single color to a color palette.
+     * @dev This function can only be called by the owner.
+     */
+    function addColorToPalette(uint8 _paletteIndex, string calldata _color) external override onlyOwner {
+        require(palettes[_paletteIndex].length <= 255, 'Palettes can only hold 256 colors');
+        _addColorToPalette(_paletteIndex, _color);
+    }
+
+    /**
+     * @notice Add a Noun background.
+     * @dev This function can only be called by the owner when not locked.
+     */
+    function addBackground(string calldata _background) external override onlyOwner whenPartsNotLocked {
+        _addBackground(_background);
+    }
+
+    /**
+     * @notice Add a Noun body.
+     * @dev This function can only be called by the owner when not locked.
+     */
+    function addBody(bytes calldata _body) external override onlyOwner whenPartsNotLocked {
+        _addBody(_body);
+    }
+
+    /**
+     * @notice Add a Noun accessory.
+     * @dev This function can only be called by the owner when not locked.
+     */
+    function addAccessory(bytes calldata _accessory) external override onlyOwner whenPartsNotLocked {
+        _addAccessory(_accessory);
+    }
+
+    /**
+     * @notice Add a Noun head.
+     * @dev This function can only be called by the owner when not locked.
+     */
+    function addHead(bytes calldata _head) external override onlyOwner whenPartsNotLocked {
+        _addHead(_head);
+    }
+
+    /**
+     * @notice Add Noun glasses.
+     * @dev This function can only be called by the owner when not locked.
+     */
+    function addGlasses(bytes calldata _glasses) external override onlyOwner whenPartsNotLocked {
+        _addGlasses(_glasses);
+    }
+    
+    /**
+     * @notice Lock all Noun parts.
+     * @dev This cannot be reversed and can only be called by the owner when not locked.
+     */
+    function lockParts() external override onlyOwner whenPartsNotLocked {
+        arePartsLocked = true;
+
+        emit PartsLocked();
+    }
+
+    /**
+     * @notice Toggle a boolean value which determines if `tokenURI` returns a data URI
+     * or an HTTP URL.
+     * @dev This can only be called by the owner.
+     */
+    function toggleDataURIEnabled() external override onlyOwner {
+        bool enabled = !isDataURIEnabled;
+
+        isDataURIEnabled = enabled;
+        emit DataURIToggled(enabled);
+    }
+
+    /**
+     * @notice Set the base URI for all token IDs. It is automatically
+     * added as a prefix to the value returned in {tokenURI}, or to the
+     * token ID if {tokenURI} is empty.
+     * @dev This can only be called by the owner.
+     */
+    function setBaseURI(string calldata _baseURI) external override onlyOwner {
+        baseURI = _baseURI;
+
+        emit BaseURIUpdated(_baseURI);
+    }
+
+    /**
+     * @notice Given a token ID and seed, construct a token URI for an official Nouns DAO noun.
+     * @dev The returned value may be a base64 encoded data URI or an API URL.
+     */
+    function tokenURI(uint256 tokenId, INounsSeeder.Seed memory seed) external view override returns (string memory) {
+        if (isDataURIEnabled) {
+            return dataURI(tokenId, seed);
+        }
+        return string(abi.encodePacked(baseURI, tokenId.toString()));
+    }
+
+    /**
+     * @notice Given a token ID and seed, construct a base64 encoded data URI for an official Nouns DAO noun.
+     */
+    function dataURI(uint256 tokenId, INounsSeeder.Seed memory seed) public view override returns (string memory) {
+        string memory nounId = tokenId.toString();
+        string memory name = string(abi.encodePacked('Noun ', nounId));
+        string memory description = string(abi.encodePacked('Noun ', nounId, ' is a member of the Nouns DAO'));
+
+        return genericDataURI(name, description, seed);
+    }
+
+    /**
+     * @notice Given a name, description, and seed, construct a base64 encoded data URI.
+     */
+    function genericDataURI(
+        string memory name,
+        string memory description,
+        INounsSeeder.Seed memory seed
+    ) public view override returns (string memory) {
+        NFTDescriptor.TokenURIParams memory params = NFTDescriptor.TokenURIParams({
+            name: name,
+            description: description,
+            parts: _getPartsForSeed(seed),
+            background: descriptor.backgrounds(seed.background)
+        });
+        return NFTDescriptor.constructTokenURI(params, palettes);
+    }
+
+    /**
+     * @notice Given a seed, construct a base64 encoded SVG image.
+     */
+    function generateSVGImage(INounsSeeder.Seed memory seed) external view override returns (string memory) {
+        MultiPartRLEToSVG.SVGParams memory params = MultiPartRLEToSVG.SVGParams({
+            parts: _getPartsForSeed(seed),
+            background: descriptor.backgrounds(seed.background)
+        });
+        return NFTDescriptor.generateSVGImage(params, palettes);
+    }
+
+    /**
+     * @notice Add a single color to a color palette.
+     */
+    function _addColorToPalette(uint8 _paletteIndex, string calldata _color) internal {
+        palettes[_paletteIndex].push(_color);
+    }
+
+    /**
+     * @notice Add a Noun background.
+     */
+    function _addBackground(string calldata _background) internal {
+        backgrounds.push(_background);
+    }
+
+    /**
+     * @notice Add a Noun body.
+     */
+
+    function _addBody(bytes calldata _body) internal {
+        // nothing
+        // bodies.push(_body);
+    }
+        
+    /**
+     * @notice Add a Noun accessory.
+     */
+    function _addAccessory(bytes calldata _accessory) internal {
+        accessories.push(_accessory);
+    }
+
+    /**
+     * @notice Add a Noun head.
+     */
+    function _addHead(bytes calldata _head) internal {
+        heads.push(_head);
+    }
+
+    /**
+     * @notice Add Noun glasses.
+     */
+    function _addGlasses(bytes calldata _glasses) internal {
+        // glasses.push(_glasses);
+    }
+    
+    /**
+     * @notice Get all Noun parts for the passed `seed`.
+     */
+    function _getPartsForSeed(INounsSeeder.Seed memory seed) internal view returns (bytes[] memory) {
+        bytes[] memory _parts = new bytes[](4);
+        _parts[0] = descriptor.bodies(seed.body);
+        _parts[1] = accessories[seed.accessory];
+        _parts[2] = heads[seed.head];
+        _parts[3] = descriptor.glasses(seed.glasses);
+        return _parts;
+    }
+}

--- a/contract/contracts/localNouns/LocalNounsDescriptor.sol
+++ b/contract/contracts/localNouns/LocalNounsDescriptor.sol
@@ -24,7 +24,7 @@ import { INounsSeeder } from './interfaces/INounsSeeder.sol';
 import { MultiPartRLEToSVG } from '../external/nouns/libs/MultiPartRLEToSVG.sol';
 import { NFTDescriptor } from '../external/nouns/libs/NFTDescriptor.sol';
 
-contract SushiNounsDescriptor is INounsDescriptor, Ownable {
+contract LocalNounsDescriptor is INounsDescriptor, Ownable {
     using Strings for uint256;
 
     // original

--- a/contract/contracts/localNouns/LocalNounsProvider.sol
+++ b/contract/contracts/localNouns/LocalNounsProvider.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+
+/*
+ * Created by Isamu Arimoto (@isamua)
+ */
+
+pragma solidity ^0.8.6;
+
+import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
+import './interfaces/IAssetProviderExMint.sol';
+import '@openzeppelin/contracts/utils/Strings.sol';
+import '@openzeppelin/contracts/interfaces/IERC165.sol';
+
+import { INounsDescriptor } from './interfaces/INounsDescriptor.sol';
+import { INounsSeeder } from './interfaces/INounsSeeder.sol';
+import { NFTDescriptor } from '../external/nouns/libs/NFTDescriptor.sol';
+
+contract SushiNounsProvider is IAssetProviderExMint, IERC165, Ownable {
+  using Strings for uint256;
+
+  string constant providerKey = 'SushiNouns';
+  address public receiver;
+
+  uint256 public nextTokenId;
+  
+  INounsDescriptor public immutable descriptor;
+  INounsDescriptor public immutable sushidescriptor;
+  INounsSeeder public immutable seeder;
+  INounsSeeder public immutable sushiseeder;
+  
+  mapping(uint256 => INounsSeeder.Seed) public seeds;
+
+  constructor(
+              INounsDescriptor _descriptor,
+              INounsDescriptor _sushidescriptor,
+              INounsSeeder _seeder,
+              INounsSeeder _sushiseeder
+              ) {
+      receiver = owner();
+
+      descriptor = _descriptor;
+      sushidescriptor = _sushidescriptor;
+      seeder = _seeder;
+      sushiseeder = _sushiseeder;
+  }
+
+  function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    return interfaceId == type(IAssetProvider).interfaceId || interfaceId == type(IERC165).interfaceId;
+  }
+
+  function getOwner() external view override returns (address) {
+    return owner();
+  }
+
+  function getProviderInfo() external view override returns (ProviderInfo memory) {
+    return ProviderInfo(providerKey, 'Logo', this);
+  }
+
+  function totalSupply() external pure override returns (uint256) {
+    return 0; // indicating "dynamically (but deterministically) generated from the given assetId)
+  }
+
+  function processPayout(uint256 _assetId) external payable override {
+    address payable payableTo = payable(receiver);
+    payableTo.transfer(msg.value);
+    emit Payout(providerKey, _assetId, payableTo, msg.value);
+  }
+
+  function setReceiver(address _receiver) external onlyOwner {
+    receiver = _receiver;
+  }
+
+  function generateSeed(uint256 _assetId) internal view returns (INounsSeeder.Seed memory mixedSeed) {
+      INounsSeeder.Seed memory seed1 = seeder.generateSeed(_assetId, descriptor);
+      INounsSeeder.Seed memory seed2 = sushiseeder.generateSeed(_assetId, sushidescriptor);
+
+      mixedSeed = INounsSeeder.Seed({
+          background: seed1.background,
+          body: seed1.body,
+          accessory: seed2.accessory,
+          head: seed2.head,
+          glasses: seed1.glasses
+      });
+
+  }
+  function generateSVGPart(uint256 _assetId) public view override returns (string memory svgPart, string memory tag) {
+      // INounsSeeder.Seed memory seed = generateSeed(_assetId);
+      INounsSeeder.Seed memory seed = seeds[_assetId];
+      svgPart = sushidescriptor.generateSVGImage(seed);
+
+      // generateSVGImage
+      tag = string("");
+      // svgPart = string("");
+  }
+
+  function generateTraits(uint256 _assetId) external pure override returns (string memory traits) {
+    // nothing to return
+  }
+
+  function mint(uint256 _assetId) external returns (uint256) {
+      if (nextTokenId == _assetId) {
+         seeds[_assetId] = generateSeed(_assetId);
+         nextTokenId ++;
+      }
+      
+     return _assetId;
+  }
+
+  
+
+}

--- a/contract/contracts/localNouns/LocalNounsProvider.sol
+++ b/contract/contracts/localNouns/LocalNounsProvider.sol
@@ -15,7 +15,7 @@ import { INounsDescriptor } from './interfaces/INounsDescriptor.sol';
 import { INounsSeeder } from './interfaces/INounsSeeder.sol';
 import { NFTDescriptor } from '../external/nouns/libs/NFTDescriptor.sol';
 
-contract SushiNounsProvider is IAssetProviderExMint, IERC165, Ownable {
+contract LocalNounsProvider is IAssetProviderExMint, IERC165, Ownable {
   using Strings for uint256;
 
   string constant providerKey = 'SushiNouns';

--- a/contract/contracts/localNouns/LocalNounsSeeder.sol
+++ b/contract/contracts/localNouns/LocalNounsSeeder.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0
+
+/// @title The NounsToken pseudo-random seed generator
+
+/*********************************
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░██░░░████░░██░░░████░░░ *
+ * ░░██████░░░████████░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ *********************************/
+
+pragma solidity ^0.8.6;
+
+import { INounsSeeder } from './interfaces/INounsSeeder.sol';
+import { INounsDescriptorMinimal } from './interfaces/INounsDescriptorMinimal.sol';
+
+contract SushiNounsSeeder is INounsSeeder {
+    /**
+     * @notice Generate a pseudo-random Noun seed using the previous blockhash and noun ID.
+     */
+    function generateSeed(uint256 nounId, INounsDescriptorMinimal descriptor) external view returns (Seed memory) {
+        uint256 pseudorandomness = uint256(
+            keccak256(abi.encodePacked(blockhash(block.number - 1), nounId))
+        );
+
+        uint256 accessoryCount = descriptor.accessoryCount();
+        uint256 headCount = descriptor.headCount();
+
+        return Seed({
+            background: 0,
+            body: 0,
+            accessory: uint48(
+                uint48(pseudorandomness >> 96) % accessoryCount
+            ),
+            head: uint48(
+                uint48(pseudorandomness >> 144) % headCount
+            ),
+            glasses: 0
+        });
+    }
+}

--- a/contract/contracts/localNouns/LocalNounsSeeder.sol
+++ b/contract/contracts/localNouns/LocalNounsSeeder.sol
@@ -20,7 +20,7 @@ pragma solidity ^0.8.6;
 import { INounsSeeder } from './interfaces/INounsSeeder.sol';
 import { INounsDescriptorMinimal } from './interfaces/INounsDescriptorMinimal.sol';
 
-contract SushiNounsSeeder is INounsSeeder {
+contract LocalNounsSeeder is INounsSeeder {
     /**
      * @notice Generate a pseudo-random Noun seed using the previous blockhash and noun ID.
      */

--- a/contract/contracts/localNouns/README.md
+++ b/contract/contracts/localNouns/README.md
@@ -1,0 +1,22 @@
+# Local nouns
+
+- [localNouns](https://github.com/Cryptocoders-wtf/local-nouns-assets/)にあるご当地nounsのheadとaccessoryを使ってNounish NFTを構成する
+
+- bodyとglassはNounsTokenのデータを参照してそのまま使う
+- headとaccessoryはstorageへ書き込む
+
+## Contractの構成
+- SushiNounsToken -> SushiNounsProvider -> SushiNounsDescriptor(NounsDescriptorを中で参照)
+- MixedSeeder(NounsSeeder, SushiNounsSeederをmixしたseeder)
+
+- データ等を重複しない構成をしている
+  - paletteが型問題で参照できないのでSushiNounsDescriptorにデータとして入れる
+- backgroundsの画像化は試したがデータ量が多いのでgas代問題でng
+  - SushiNounsDescriptorのpartsを5個にし、NFTDescriptorを改良すればできる
+- mint時にseedはproviderで管理する
+  - seederの受け渡しに問題でtokenで管理していない
+
+## deploy & test
+ - test/sushi.ts　にテストがある
+   - これを参照すればdeployもつくれる。
+ - nouns daoのcontracのデータを参照するので、mainnet forkingで動かす必要がある

--- a/contract/contracts/localNouns/interfaces/IAssetProviderExMint.sol
+++ b/contract/contracts/localNouns/interfaces/IAssetProviderExMint.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.6;
+
+import 'assetprovider.sol/IAssetProvider.sol';
+
+interface IAssetProviderExMint is IAssetProvider {
+    function mint(uint256 _assetId) external returns (uint256);
+}

--- a/contract/contracts/localNouns/interfaces/INounsDescriptor.sol
+++ b/contract/contracts/localNouns/interfaces/INounsDescriptor.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0
+
+/// @title Interface for NounsDescriptor
+
+/*********************************
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░██░░░████░░██░░░████░░░ *
+ * ░░██████░░░████████░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ *********************************/
+
+pragma solidity ^0.8.6;
+
+import { INounsSeeder } from './INounsSeeder.sol';
+import { INounsDescriptorMinimal } from './INounsDescriptorMinimal.sol';
+
+interface INounsDescriptor is INounsDescriptorMinimal {
+    event PartsLocked();
+
+    event DataURIToggled(bool enabled);
+
+    event BaseURIUpdated(string baseURI);
+
+    function arePartsLocked() external returns (bool);
+
+    function isDataURIEnabled() external returns (bool);
+
+    function baseURI() external returns (string memory);
+
+    function palettes(uint8 paletteIndex, uint256 colorIndex) external view returns (string memory);
+
+    function backgrounds(uint256 index) external view returns (string memory);
+
+    function bodies(uint256 index) external view returns (bytes memory);
+
+    function accessories(uint256 index) external view returns (bytes memory);
+
+    function heads(uint256 index) external view returns (bytes memory);
+
+    function glasses(uint256 index) external view returns (bytes memory);
+
+    function backgroundCount() external view override returns (uint256);
+
+    function bodyCount() external view override returns (uint256);
+
+    function accessoryCount() external view override returns (uint256);
+
+    function headCount() external view override returns (uint256);
+
+    function glassesCount() external view override returns (uint256);
+
+    function addManyColorsToPalette(uint8 paletteIndex, string[] calldata newColors) external;
+
+    function addManyBackgrounds(string[] calldata backgrounds) external;
+
+    function addManyBodies(bytes[] calldata bodies) external;
+
+    function addManyAccessories(bytes[] calldata accessories) external;
+
+    function addManyHeads(bytes[] calldata heads) external;
+
+    function addManyGlasses(bytes[] calldata glasses) external;
+
+    function addColorToPalette(uint8 paletteIndex, string calldata color) external;
+
+    function addBackground(string calldata background) external;
+
+    function addBody(bytes calldata body) external;
+
+    function addAccessory(bytes calldata accessory) external;
+
+    function addHead(bytes calldata head) external;
+
+    function addGlasses(bytes calldata glasses) external;
+
+    function lockParts() external;
+
+    function toggleDataURIEnabled() external;
+
+    function setBaseURI(string calldata baseURI) external;
+
+    function tokenURI(uint256 tokenId, INounsSeeder.Seed memory seed) external view override returns (string memory);
+
+    function dataURI(uint256 tokenId, INounsSeeder.Seed memory seed) external view override returns (string memory);
+
+    function genericDataURI(
+        string calldata name,
+        string calldata description,
+        INounsSeeder.Seed memory seed
+    ) external view returns (string memory);
+
+    function generateSVGImage(INounsSeeder.Seed memory seed) external view returns (string memory);
+}

--- a/contract/contracts/localNouns/interfaces/INounsDescriptorMinimal.sol
+++ b/contract/contracts/localNouns/interfaces/INounsDescriptorMinimal.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0
+
+/// @title Common interface for NounsDescriptor versions, as used by NounsToken and NounsSeeder.
+
+/*********************************
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░██░░░████░░██░░░████░░░ *
+ * ░░██████░░░████████░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ *********************************/
+
+pragma solidity ^0.8.6;
+
+import { INounsSeeder } from './INounsSeeder.sol';
+
+interface INounsDescriptorMinimal {
+    ///
+    /// USED BY TOKEN
+    ///
+
+    function tokenURI(uint256 tokenId, INounsSeeder.Seed memory seed) external view returns (string memory);
+
+    function dataURI(uint256 tokenId, INounsSeeder.Seed memory seed) external view returns (string memory);
+
+    ///
+    /// USED BY SEEDER
+    ///
+
+    function backgroundCount() external view returns (uint256);
+
+    function bodyCount() external view returns (uint256);
+
+    function accessoryCount() external view returns (uint256);
+
+    function headCount() external view returns (uint256);
+
+    function glassesCount() external view returns (uint256);
+}

--- a/contract/contracts/localNouns/interfaces/INounsSeeder.sol
+++ b/contract/contracts/localNouns/interfaces/INounsSeeder.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0
+
+/// @title Interface for NounsSeeder
+
+/*********************************
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░██░░░████░░██░░░████░░░ *
+ * ░░██████░░░████████░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ *********************************/
+
+pragma solidity ^0.8.6;
+
+import { INounsDescriptorMinimal } from './INounsDescriptorMinimal.sol';
+
+interface INounsSeeder {
+    struct Seed {
+        uint48 background;
+        uint48 body;
+        uint48 accessory;
+        uint48 head;
+        uint48 glasses;
+    }
+
+    function generateSeed(uint256 nounId, INounsDescriptorMinimal descriptor) external view returns (Seed memory);
+}


### PR DESCRIPTION
ご当地Nounsは、sushi-Nounsのコントラクト群を元に作成します。
修正履歴を追うため、ファイル名だけ変更したバージョンをpushします。