### PR TITLE
[LocalNouns]Minter設定

### DIFF
--- a/contract/contracts/LocalNounsToken.sol
+++ b/contract/contracts/LocalNounsToken.sol
@@ -14,38 +14,26 @@ import './localNouns/interfaces/IAssetProviderExMint.sol';
 contract LocalNounsToken is ProviderTokenA1 {
   using Strings for uint256;
 
-  // fes committee
-  address public committee;
-  address public designer;
-  address public developper;
-
   IAssetProviderExMint public assetProvider2;
 
-  constructor(
-    IAssetProviderExMint _assetProvider,
-    address _committee,
-    address _designer,
-    address _developper
-  ) ProviderTokenA1(_assetProvider, 'Local Nouns', 'Local Nouns') {
+  constructor(IAssetProviderExMint _assetProvider) ProviderTokenA1(_assetProvider, 'Local Nouns', 'Local Nouns') {
     description = 'Local Nouns Token.';
     assetProvider2 = _assetProvider;
-    mintPrice = 1e13; // 0.001 
+    mintPrice = 1e13; // 0.001
     mintLimit = 5000;
-    committee = _committee;
-    designer = _designer;
-    developper = _developper;
   }
 
   function tokenName(uint256 _tokenId) internal pure override returns (string memory) {
     return string(abi.encodePacked('Local Nouns ', _tokenId.toString()));
   }
-  function tokenURI(uint256 _tokenId) public view override returns (string memory) {
-      require(_tokenId < _nextTokenId(), 'LocalNounsToken.tokenURI: nonexistent token');
 
-      (string memory svgPart, string memory tag) = assetProvider2.generateSVGPart(_tokenId);
-      bytes memory image = bytes(svgPart);
-          
-          return
+  function tokenURI(uint256 _tokenId) public view override returns (string memory) {
+    require(_tokenId < _nextTokenId(), 'LocalNounsToken.tokenURI: nonexistent token');
+
+    (string memory svgPart, string memory tag) = assetProvider2.generateSVGPart(_tokenId);
+    bytes memory image = bytes(svgPart);
+
+    return
       string(
         abi.encodePacked(
           'data:application/json;base64,',
@@ -67,19 +55,12 @@ contract LocalNounsToken is ProviderTokenA1 {
         )
       );
   }
+
   function mint(uint256 prefectureId) public payable virtual returns (uint256 tokenId) {
-      require(msg.value >= mintPrice, 'Must send the mint price');
-      assetProvider2.mint(prefectureId, _nextTokenId());
-      super.mint();
-      address payable payableTo = payable(committee);
-      payableTo.transfer(address(this).balance);
-      
-      // if ((_nextTokenId() % 10) == 8) {
-      //     assetProvider2.mint(_nextTokenId());
-      //     _safeMint(designer, 1);
-      //     assetProvider2.mint(_nextTokenId());
-      //     _safeMint(developper, 1);
-      // }
-      return _nextTokenId() - 1;
+    require(msg.value >= mintPrice, 'Must send the mint price');
+    assetProvider2.mint(prefectureId, _nextTokenId());
+    super.mint();
+
+    return _nextTokenId() - 1;
   }
 }

--- a/contract/contracts/LocalNounsToken.sol
+++ b/contract/contracts/LocalNounsToken.sol
@@ -15,12 +15,15 @@ contract LocalNounsToken is ProviderTokenA1 {
   using Strings for uint256;
 
   IAssetProviderExMint public assetProvider2;
+  address public minter;
 
-  constructor(IAssetProviderExMint _assetProvider) ProviderTokenA1(_assetProvider, 'Local Nouns', 'Local Nouns') {
+  constructor(IAssetProviderExMint _assetProvider, address _minter) ProviderTokenA1(_assetProvider, 'Local Nouns', 'Local Nouns') {
     description = 'Local Nouns Token.';
     assetProvider2 = _assetProvider;
-    mintPrice = 1e13; // 0.001
+    // mintPrice = 1e13; // 0.001
+    mintPrice = 0; 
     mintLimit = 5000;
+    minter = _minter;
   }
 
   function tokenName(uint256 _tokenId) internal pure override returns (string memory) {
@@ -58,6 +61,7 @@ contract LocalNounsToken is ProviderTokenA1 {
 
   function mint(uint256 prefectureId) public payable virtual returns (uint256 tokenId) {
     require(msg.value >= mintPrice, 'Must send the mint price');
+    require(msg.sender != minter, 'sender is not the minter');
     assetProvider2.mint(prefectureId, _nextTokenId());
     super.mint();
 

--- a/contract/scripts/deploy_localNouns.ts
+++ b/contract/scripts/deploy_localNouns.ts
@@ -52,7 +52,7 @@ async function main() {
   const token = await factoryToken.deploy(provider.address, minter.address);
   await token.deployed();
   console.log(`##LocalNounsToken="${token.address}"`);
-  await runCommand(`npx hardhat verify ${token.address} ${provider.address} ${minter} --network ${network.name} &`);
+  await runCommand(`npx hardhat verify ${token.address} ${provider.address} ${minter.address} --network ${network.name} &`);
 
   const addresses4 = `export const addresses = {\n` + `  localNounsToken:"${token.address}",\n` + `}\n`;
   await writeFile(`../src/utils/addresses/localNounsToken_${network.name}.ts`, addresses4, () => {});

--- a/contract/scripts/deploy_localNouns.ts
+++ b/contract/scripts/deploy_localNouns.ts
@@ -7,10 +7,10 @@ const nounsDescriptor = addresses.nounsDescriptor[network.name];
 const nounsSeeder = addresses.nounsSeeder[network.name];
 const nftDescriptor = addresses.nftDescriptor[network.name];
 
-const committee = "0x52A76a606AC925f7113B4CC8605Fe6bCad431EbB";
-// const committee = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"; // localhost
-
 async function main() {
+
+  const [minter] = await ethers.getSigners();
+  console.log(`##minter="${minter}"`);
 
   const factorySeeder = await ethers.getContractFactory('LocalNounsSeeder');
   const localseeder = await factorySeeder.deploy();
@@ -49,10 +49,10 @@ async function main() {
   
 
   const factoryToken = await ethers.getContractFactory('LocalNounsToken');
-  const token = await factoryToken.deploy(provider.address, committee, committee, committee);
+  const token = await factoryToken.deploy(provider.address, minter.address);
   await token.deployed();
   console.log(`##LocalNounsToken="${token.address}"`);
-  await runCommand(`npx hardhat verify ${token.address} ${provider.address} ${committee} ${committee} ${committee} --network ${network.name} &`);
+  await runCommand(`npx hardhat verify ${token.address} ${provider.address} ${minter} --network ${network.name} &`);
 
   const addresses4 = `export const addresses = {\n` + `  localNounsToken:"${token.address}",\n` + `}\n`;
   await writeFile(`../src/utils/addresses/localNounsToken_${network.name}.ts`, addresses4, () => {});

--- a/contract/scripts/populate_localNouns.ts
+++ b/contract/scripts/populate_localNouns.ts
@@ -60,9 +60,9 @@ async function main() {
 
   for (var i: number = 1; i <= 47; i++) {
     try {
-      await localToken.functions['mint(uint256)'](ethers.BigNumber.from(String(i)), { value: ethers.utils.parseEther('0.001') });
-      await localToken.functions['mint(uint256)'](ethers.BigNumber.from(String(i)), { value: ethers.utils.parseEther('0.001') });
-      await localToken.functions['mint(uint256)'](ethers.BigNumber.from(String(i)), { value: ethers.utils.parseEther('0.001') });
+      await localToken.functions['mint(uint256)'](ethers.BigNumber.from(String(i)));
+      await localToken.functions['mint(uint256)'](ethers.BigNumber.from(String(i)));
+
       console.log(`mint [`, i, `]`);
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
アローリスト条件やミント価格などをLocalNounsToken.solのmint関数でなく、Minter用のコントラクトを作成してそちらで制御するようにします。
まずはMinter指定したアドレスであればミントOKとするよう修正しました。

この後、Minterコントラクトを作成します。