### PR TITLE
[LocalNouns]Minterコントラクト追加

### DIFF
--- a/contract/contracts/LocalNounsToken.sol
+++ b/contract/contracts/LocalNounsToken.sol
@@ -68,6 +68,10 @@ contract LocalNounsToken is ProviderTokenA1, ILocalNounsToken {
     return _nextTokenId() - 1;
   }
 
+  function mint() public payable override returns (uint256 tokenId) {
+    revert('Cannot use this function');
+  }
+
   function setMinter(address _minter) public onlyOwner {
     minter = _minter;
   }

--- a/contract/contracts/LocalNounsToken.sol
+++ b/contract/contracts/LocalNounsToken.sol
@@ -10,8 +10,9 @@ import '@openzeppelin/contracts/utils/Strings.sol';
 import './libs/ProviderTokenA1.sol';
 import { INounsSeeder } from './localNouns/interfaces/INounsSeeder.sol';
 import './localNouns/interfaces/IAssetProviderExMint.sol';
+import './localNouns/interfaces/ILocalNounsToken.sol';
 
-contract LocalNounsToken is ProviderTokenA1 {
+contract LocalNounsToken is ProviderTokenA1, ILocalNounsToken {
   using Strings for uint256;
 
   IAssetProviderExMint public assetProvider2;
@@ -59,12 +60,15 @@ contract LocalNounsToken is ProviderTokenA1 {
       );
   }
 
-  function mint(uint256 prefectureId) public payable virtual returns (uint256 tokenId) {
-    require(msg.value >= mintPrice, 'Must send the mint price');
-    require(msg.sender != minter, 'sender is not the minter');
+  function mintSelectedPrefecture(uint256 prefectureId) public virtual returns (uint256 tokenId) {
+    require(msg.sender == minter, 'Sender is not the minter');
     assetProvider2.mint(prefectureId, _nextTokenId());
     super.mint();
 
     return _nextTokenId() - 1;
+  }
+
+  function setMinter(address _minter) public onlyOwner {
+    minter = _minter;
   }
 }

--- a/contract/contracts/localNouns/LocalNounsMinter.sol
+++ b/contract/contracts/localNouns/LocalNounsMinter.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0
+
+/// @title Interface for NounsSeeder
+
+/*********************************
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░██░░░████░░██░░░████░░░ *
+ * ░░██████░░░████████░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ *********************************/
+
+pragma solidity ^0.8.6;
+
+import { Ownable } from '@openzeppelin/contracts/access/Ownable.sol';
+import './interfaces/ILocalNounsToken.sol';
+
+contract LocalNounsMinter is Ownable {
+  ILocalNounsToken public token;
+
+  constructor(ILocalNounsToken _token) {
+    token = _token;
+  }
+
+  function setLocalNounsToken(ILocalNounsToken _token) external onlyOwner {
+    token = _token;
+  }
+
+  function mintSelectedPrefecture(uint256 _prefectureId) public payable returns (uint256 tokenId) {
+    return token.mintSelectedPrefecture(_prefectureId);
+  }
+}

--- a/contract/contracts/localNouns/interfaces/ILocalNounsToken.sol
+++ b/contract/contracts/localNouns/interfaces/ILocalNounsToken.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-3.0
+
+/// @title Interface for NounsSeeder
+
+/*********************************
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░██░░░████░░██░░░████░░░ *
+ * ░░██████░░░████████░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░██░░██░░░████░░██░░░████░░░ *
+ * ░░░░░░█████████░░█████████░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ * ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ *
+ *********************************/
+
+pragma solidity ^0.8.6;
+
+interface ILocalNounsToken {
+  function mintSelectedPrefecture(uint256 prefectureId) external returns (uint256 tokenId);
+
+  function setMinter(address _minter) external;
+}

--- a/contract/scripts/deploy_localNouns.ts
+++ b/contract/scripts/deploy_localNouns.ts
@@ -10,7 +10,7 @@ const nftDescriptor = addresses.nftDescriptor[network.name];
 async function main() {
 
   const [minter] = await ethers.getSigners();
-  console.log(`##minter="${minter}"`);
+  console.log(`##minter="${minter.address}"`);
 
   const factorySeeder = await ethers.getContractFactory('LocalNounsSeeder');
   const localseeder = await factorySeeder.deploy();
@@ -19,7 +19,7 @@ async function main() {
   await runCommand(`npx hardhat verify ${localseeder.address} --network ${network.name} &`);
 
   const addresses = `export const addresses = {\n` + `  localseeder:"${localseeder.address}",\n` + `}\n`;
-  await writeFile(`../src/utils/addresses/localseeder_${network.name}.ts`, addresses, () => {});
+  await writeFile(`../src/utils/addresses/localseeder_${network.name}.ts`, addresses, () => { });
 
 
   const factoryLocalNounsDescriptor = await ethers.getContractFactory('LocalNounsDescriptor', {
@@ -35,7 +35,7 @@ async function main() {
   await runCommand(`npx hardhat verify ${localNounsDescriptor.address} ${nounsDescriptor} --network ${network.name} &`);
 
   const addresses2 = `export const addresses = {\n` + `  localNounsDescriptor:"${localNounsDescriptor.address}",\n` + `}\n`;
-  await writeFile(`../src/utils/addresses/localNounsDescriptor_${network.name}.ts`, addresses2, () => {});
+  await writeFile(`../src/utils/addresses/localNounsDescriptor_${network.name}.ts`, addresses2, () => { });
 
 
   const factorySVGStore = await ethers.getContractFactory('LocalNounsProvider');
@@ -45,8 +45,7 @@ async function main() {
   await runCommand(`npx hardhat verify ${provider.address} ${nounsDescriptor} ${localNounsDescriptor.address} ${nounsSeeder} ${localseeder.address} --network ${network.name} &`);
 
   const addresses3 = `export const addresses = {\n` + `  localNounsProvider:"${provider.address}",\n` + `}\n`;
-  await writeFile(`../src/utils/addresses/localNounsProvider_${network.name}.ts`, addresses3, () => {});
-  
+  await writeFile(`../src/utils/addresses/localNounsProvider_${network.name}.ts`, addresses3, () => { });
 
   const factoryToken = await ethers.getContractFactory('LocalNounsToken');
   const token = await factoryToken.deploy(provider.address, minter.address);
@@ -55,7 +54,18 @@ async function main() {
   await runCommand(`npx hardhat verify ${token.address} ${provider.address} ${minter.address} --network ${network.name} &`);
 
   const addresses4 = `export const addresses = {\n` + `  localNounsToken:"${token.address}",\n` + `}\n`;
-  await writeFile(`../src/utils/addresses/localNounsToken_${network.name}.ts`, addresses4, () => {});
+  await writeFile(`../src/utils/addresses/localNounsToken_${network.name}.ts`, addresses4, () => { });
+
+  const factoryMinter = await ethers.getContractFactory('LocalNounsMinter');
+  const minterContract = await factoryMinter.deploy(token.address);
+  await minterContract.deployed();
+  console.log(`##LocalNounsMinter="${minterContract.address}"`);
+  await runCommand(`npx hardhat verify ${minterContract.address} ${token.address} --network ${network.name} &`);
+
+  const addresses5 = `export const addresses = {\n` + `  localNounsMinter:"${minterContract.address}",\n` + `}\n`;
+  await writeFile(`../src/utils/addresses/localNounsMinter_${network.name}.ts`, addresses5, () => { });
+
+  await token.setMinter(minterContract.address);
 
 }
 

--- a/contract/scripts/populate_localNouns.ts
+++ b/contract/scripts/populate_localNouns.ts
@@ -9,6 +9,7 @@ import { abi as localSeederABI } from "../artifacts/contracts/localNouns/LocalNo
 import { abi as localNounsDescriptorABI } from "../artifacts/contracts/localNouns/LocalNounsDescriptor.sol/LocalNounsDescriptor";
 import { abi as localProviderABI } from "../artifacts/contracts/localNouns/LocalNounsProvider.sol/LocalNounsProvider";
 import { abi as localTokenABI } from "../artifacts/contracts/LocalNounsToken.sol/LocalNounsToken";
+import { abi as localMinterABI } from "../artifacts/contracts/localNouns/LocalNounsMinter.sol/LocalNounsMinter";
 
 dotenv.config();
 
@@ -17,20 +18,22 @@ const localSeederAddress = addresses.localSeeder[network.name];
 const localNounsDescriptorAddress = addresses.localNounsDescriptor[network.name];
 const localProviderAddress = addresses.localProvider[network.name];
 const localTokenAddress = addresses.localNounsToken[network.name];
+const localMinterAddress = addresses.localNounsMinter[network.name];
 
 async function main() {
   
-  const privateKey = process.env.PRIVATE_KEY !== undefined ? process.env.PRIVATE_KEY : '';
-  const wallet = new ethers.Wallet(privateKey, ethers.provider);
-  // const [wallet] = await ethers.getSigners(); // localhost
+  // const privateKey = process.env.PRIVATE_KEY !== undefined ? process.env.PRIVATE_KEY : '';
+  // const wallet = new ethers.Wallet(privateKey, ethers.provider);
+  const [wallet] = await ethers.getSigners(); // localhost
 
   // ethers.Contract オブジェクトのインスタンスを作成
   const localSeeder = new ethers.Contract(localSeederAddress, localSeederABI, wallet);
   const localNounsDescriptor = new ethers.Contract(localNounsDescriptorAddress, localNounsDescriptorABI, wallet);
   const localProvider = new ethers.Contract(localProviderAddress, localProviderABI, wallet);
   const localToken = new ethers.Contract(localTokenAddress, localTokenABI, wallet);
+  const localMinter = new ethers.Contract(localMinterAddress, localMinterABI, wallet);
 
-  if (true) {
+  if (false) {
     // set Palette
     console.log(`set Palette start`);
     await localNounsDescriptor.addManyColorsToPalette(0, palette);
@@ -58,10 +61,9 @@ async function main() {
 
   }
 
-  for (var i: number = 1; i <= 47; i++) {
+  for (var i: number = 1; i <= 1; i++) {
     try {
-      await localToken.functions['mint(uint256)'](ethers.BigNumber.from(String(i)));
-      await localToken.functions['mint(uint256)'](ethers.BigNumber.from(String(i)));
+      await localMinter.functions['mintSelectedPrefecture(uint256)'](ethers.BigNumber.from(String(i)), { value: ethers.utils.parseEther('0.000001') });
 
       console.log(`mint [`, i, `]`);
     } catch (error) {

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -87,6 +87,7 @@ import { addresses as localSeeder_mumbai } from "./addresses/localseeder_mumbai"
 import { addresses as localNounsDescriptor_mumbai } from "./addresses/localNounsDescriptor_mumbai";
 import { addresses as localProvider_mumbai } from "./addresses/localNounsProvider_mumbai";
 import { addresses as localNounsToken_mumbai } from "./addresses/localNounsToken_mumbai";
+import { addresses as localNounsMinter_mumbai } from "./addresses/localNounsMinter_mumbai";
 
 export interface Addresses {
   [key: string]: { [key: string]: string };
@@ -314,14 +315,22 @@ export const addresses: Addresses = {
 
   localSeeder: {
     mumbai: localSeeder_mumbai.localseeder,
+    localhost: localSeeder_mumbai.localseeder,
   },
   localNounsDescriptor: {
     mumbai: localNounsDescriptor_mumbai.localNounsDescriptor,
+    localhost: localNounsDescriptor_mumbai.localNounsDescriptor,
   },
   localProvider: {
     mumbai: localProvider_mumbai.localNounsProvider,
+    localhost: localProvider_mumbai.localNounsProvider,
   },
   localNounsToken: {
     mumbai: localNounsToken_mumbai.localNounsToken,
+    localhost: localNounsToken_mumbai.localNounsToken,
+  },
+  localNounsMinter: {
+    mumbai: localNounsMinter_mumbai.localNounsMinter,
+    localhost: localNounsMinter_mumbai.localNounsMinter,
   },
 };

--- a/src/utils/addresses/localNounsDescriptor_localhost.ts
+++ b/src/utils/addresses/localNounsDescriptor_localhost.ts
@@ -1,0 +1,3 @@
+export const addresses = {
+  localNounsDescriptor:"0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
+}

--- a/src/utils/addresses/localNounsDescriptor_mumbai.ts
+++ b/src/utils/addresses/localNounsDescriptor_mumbai.ts
@@ -1,3 +1,3 @@
 export const addresses = {
-  localNounsDescriptor:"0x1A88f19d94ceCe2A352E8178ddF570855317C15d",
+  localNounsDescriptor:"0xc0ce1B8DCd1045Ded1aBc983eb0577C91Dc67e0f",
 }

--- a/src/utils/addresses/localNounsMinter_localhost.ts
+++ b/src/utils/addresses/localNounsMinter_localhost.ts
@@ -1,0 +1,3 @@
+export const addresses = {
+  localNounsMinter:"0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
+}

--- a/src/utils/addresses/localNounsMinter_mumbai.ts
+++ b/src/utils/addresses/localNounsMinter_mumbai.ts
@@ -1,0 +1,3 @@
+export const addresses = {
+  localNounsMinter:"0x461F5E3658380593E9a08D84c9074a8C9FE1fe1F",
+}

--- a/src/utils/addresses/localNounsProvider_localhost.ts
+++ b/src/utils/addresses/localNounsProvider_localhost.ts
@@ -1,0 +1,3 @@
+export const addresses = {
+  localNounsProvider:"0x0165878A594ca255338adfa4d48449f69242Eb8F",
+}

--- a/src/utils/addresses/localNounsProvider_mumbai.ts
+++ b/src/utils/addresses/localNounsProvider_mumbai.ts
@@ -1,3 +1,3 @@
 export const addresses = {
-  localNounsProvider:"0x6AE64719EB925B7a1d935d45F24A30094a12C9D4",
+  localNounsProvider:"0x8d65Dd27E7910C18E6B83976753e912137f97454",
 }

--- a/src/utils/addresses/localNounsToken_localhost.ts
+++ b/src/utils/addresses/localNounsToken_localhost.ts
@@ -1,0 +1,3 @@
+export const addresses = {
+  localNounsToken:"0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
+}

--- a/src/utils/addresses/localNounsToken_mumbai.ts
+++ b/src/utils/addresses/localNounsToken_mumbai.ts
@@ -1,3 +1,3 @@
 export const addresses = {
-  localNounsToken:"0x1f26A1E07bF4e939144EE85833EFdEB46859AbBB",
+  localNounsToken:"0xbf1028b9CE3A40b1C13329dcb8a17ab9B96ffdA5",
 }

--- a/src/utils/addresses/localseeder_localhost.ts
+++ b/src/utils/addresses/localseeder_localhost.ts
@@ -1,0 +1,3 @@
+export const addresses = {
+  localseeder:"0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
+}

--- a/src/utils/addresses/localseeder_mumbai.ts
+++ b/src/utils/addresses/localseeder_mumbai.ts
@@ -1,3 +1,3 @@
 export const addresses = {
-  localseeder:"0x6eE769B88423F0bddAEdb4Cd8C188b5a4366814D",
+  localseeder:"0x87ca24C18dC424Bc3018F4955aca1AC123d52A97",
 }


### PR DESCRIPTION
Minter用のコントラクト LocalNounsMinterからmint可能とします。
LocalNounsTokenのインターフェース ILocalNounsMinterでプロキシコールでmintします。

現時点でlocalhostではmint関数が成功しますが、mumbaiではエラーになります。
Mainnet Forkingで原因探っていきます。
